### PR TITLE
Change AnimatedSwitch key to location.pathname

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -36,7 +36,7 @@ export default class App extends Component {
 					render={({ location }) => (
 						<TransitionGroup component="main">
 							<AnimatedSwitch
-								key={location.key}
+								key={location.pathname}
 								location={location}
 							>
 								<Route exact path="/" component={Home} />


### PR DESCRIPTION
This avoids "re-animation" of same route when clicking in the same route link.
That happens 'cos `location.key` always change on every route change (even the same route), but the `location.pathname` obviously only changes on different routes.

PS: Great article on hackermoon